### PR TITLE
Move `env_logger` to `dev-dependencies`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,11 @@ readme = "README.md"
 
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }
+env_logger = "0.9.0"
 tokio = { version = "1", features = ["io-std", "signal"] }
-
 
 [dependencies]
 bytes = "1.1.0"
-env_logger = "0.9.0"
 log = { version = "0.4.17" }
 octseq = { git = "https://github.com/NLnetLabs/octseq", features = ["bytes"] }
 routecore = { version = "0.4.0-dev", features = ["bgp", "bmp"], git = "https://github.com/NLnetLabs/routecore.git", branch = "compose-messages-nlri-v2" }


### PR DESCRIPTION
Libraries don't need logger impls, only the log facade. This crate actually doesn't use `env_logger` either, it is only present for the `bgpsink` example.

Moving this also resolves https://rustsec.org/advisories/RUSTSEC-2021-0145 which affects this crate because of the `env_logger` dependency like so, although presumably as `env_logger` isn't actually used in the library itself it shouldn't matter that much but still it's nice to clean up:

```
❯ cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 574 security advisories (from /home/ximon/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (283 crate dependencies)
Crate:     atty
Version:   0.2.14
Warning:   unsound
Title:     Potential unaligned read
Date:      2021-07-04
ID:        RUSTSEC-2021-0145
URL:       https://rustsec.org/advisories/RUSTSEC-2021-0145
Dependency tree:
atty 0.2.14
└── env_logger 0.9.3
    └── rotonda-fsm 0.1.0-dev
```